### PR TITLE
Instruct git to preserve .sh line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+*.txt text=auto
+
+# Set line endings to LF, even on Windows. Otherwise, execution within Docker fails.
+# See https://help.github.com/articles/dealing-with-line-endings/
+*.sh text eol=lf


### PR DESCRIPTION
Fixes #1 by enforcing Windows git clone to preserve Unix line endings.

See:
https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
and
https://willi.am/blog/2016/08/11/docker-for-windows-dealing-with-windows-line-endings/
and
https://techblog.dorogin.com/case-of-windows-line-ending-in-bash-script-7236f056abe