### PR TITLE
Adds experimental DeepSpeed variant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ CMD ["python3", "/app/server.py"]
 
 FROM base AS deepspeed
 RUN echo "DEEPSPEED" >> /variant.txt
-RUN apt-get install --no-install-recommends -y git python3-dev build-essential python3-pip libmpich-dev
+RUN apt-get install --no-install-recommends -y git python3-dev build-essential python3-pip libmpich-dev libaio-dev
 RUN pip install mpi4py deepspeed
 ENV EXTRA_LAUNCH_ARGS=""
 CMD ["deepspeed", "--num_gpus=1", "/app/server.py", "--deepspeed"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,13 @@ RUN pip3 uninstall -y quant-cuda && \
 ENV EXTRA_LAUNCH_ARGS=""
 CMD ["python3", "/app/server.py"]
 
+FROM base AS deepspeed
+RUN echo "DEEPSPEED" >> /variant.txt
+RUN apt-get install --no-install-recommends -y git python3-dev build-essential python3-pip libmpich-dev
+RUN pip install mpi4py deepspeed
+ENV EXTRA_LAUNCH_ARGS=""
+CMD ["deepspeed", "--num_gpus=1", "/app/server.py", "--deepspeed"]
+
 FROM base AS llama-cublas
 RUN echo "LLAMA-CUBLAS" >> /variant.txt
 RUN apt-get install --no-install-recommends -y git python3-dev build-essential python3-pip


### PR DESCRIPTION
### What Changed?

This PR adds the DeepSpeed wrapper in order to use the ZeRO-3 optimization as documented [in oobabooga's DeepSpeed.md](https://github.com/oobabooga/text-generation-webui/blob/main/docs/DeepSpeed.md).

### Why?

This enables loading large models with limited VRAM with higher performance than the standard GPU offloading or using GGML with llama.cpp.

### What still needs work

- [ ] Allow the user to customize the number of GPUs they have (`--num_gpus`)
- [x] Allow the user to use nvme offloading (`--nvme-offload-dir`) and install `libaio-dev` as described in [#40](https://github.com/oobabooga/text-generation-webui/issues/40#issuecomment-1412038622).
- [ ] Update readme.

### Testing

I tested this in Docker running with WSL2. Allocating less than ~24GB of system memory results in a -9 exit code. Additional testing may be needed.