### PR TITLE
fix: arguments arrays preservation on Launcher entrypoint

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -54,7 +54,7 @@ echo "=== Image build date: $BUILD_DATE ==="
 
 # Assemble CMD and extra launch args
 eval "extra_launch_args=($EXTRA_LAUNCH_ARGS)"
-LAUNCHER=($@ ${extra_launch_args[@]})
+LAUNCHER=("$@" "${extra_launch_args[@]}")
 
 # Launch the server with ${CMD[@]} + ${EXTRA_LAUNCH_ARGS[@]}
 exec "${LAUNCHER[@]}"


### PR DESCRIPTION
I actually questioning why you really need this entrypoint with its complex args passing mechanism. My issue is cannot run this container with custom command where I need to mount to user data for persistent files. The original entrypoint is not allowed me to even use `/bin/bash -c "echo something > /tmp/test.txt"` and just output empty while, with no file created, but exit 0.

I assume this entrypoint would allow you (creator) to do some warm up to the system (by using entrypoint), while separate the application calling (using CMD), and let user to redefine textgen parameters (using env `EXTRA_LAUNCH_ARGS`). So, here some proof of concept I done.

> For more context, I try to run this image in RunPod where I can't change the entrypoint. I need to do the `if workspace empty, then copy the user data. Symlink the workspace into the userdata every startup`.

I just make a simple `./launcher.sh` with `chmod +x`.
```sh
#!/bin/bash

eval "extra_launch_args=($EXTRA_LAUNCH_ARGS)"
LAUNCHER=("$@" "${extra_launch_args[@]}")

echo $LAUNCHER
echo "$LAUNCHER"
echo "${LAUNCHER[@]}"
exec "${LAUNCHER[@]}"
```

The objective:
```sh
export EXTRA_LAUNCH_ARGS="--listen --api --verbose"
./launcher.sh python3 /app/server.py
```

---

Simple test: `./test.sh`:
```sh
#!/bin/bash

echo "$@"
echo "$*"
echo "$#"
```

I run:
```sh
export EXTRA_LAUNCH_ARGS='-c "echo hello $SHELL world" --listen --api'
./launcher.sh /bin/bash ./test.sh
```

Output:
```
/bin/bash
/bin/bash
/bin/bash ./c.sh -c echo hello /usr/bin/zsh world --listen --api
-c echo hello /usr/bin/zsh world --listen --api
-c echo hello /usr/bin/zsh world --listen --api
4
```

---

I run:
```sh
export EXTRA_LAUNCH_ARGS='-c "echo hello $SHELL world"'
./launcher.sh /bin/bash
```

Output:
```
/bin/bash
/bin/bash
/bin/bash -c echo hello /usr/bin/zsh world
hello /usr/bin/zsh world
```